### PR TITLE
fix regex: accept tabs and spaces as separator

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,5 +8,5 @@
 - name: remove swap from fstab
   lineinfile:
     path: '/etc/fstab'
-    regexp: ' swap '
+    regexp: '\sswap\s'
     state: 'absent'


### PR DESCRIPTION
tested on fresh install of ubuntu 20 TLS, /etc/fstab is using tabs to separate columns.